### PR TITLE
feat: add 'Groups' section to navbar 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,105 @@ git push origin main
 
 Then, go to the original repository on GitHub and open a Pull Request. We will review your contribution and merge it if everything looks good.
 
+## Organizing Blogs into Groups
+
+The Zeus Project organizes blog posts into thematic learning groups to provide structured learning paths. Each group represents a major topic area in machine learning and data science.
+
+### Current Learning Groups
+
+We currently have six main learning groups:
+
+1. **Classical ML** - Fundamental machine learning algorithms and concepts
+2. **Deep Learning** - Neural networks and deep learning architectures
+3. **Natural Language Processing** - Text processing and language understanding
+4. **Computer Vision** - Image processing and visual AI
+5. **Reinforcement Learning** - Decision-making and sequential learning
+6. **MLOps & Deployment** - Production ML systems and deployment
+
+### How to Add a Blog to a Group
+
+When contributing a new blog post, you should add it to the appropriate learning group to ensure it appears in the group's lesson list and contributes to the group's progress tracking.
+
+#### Step 1: Identify the Appropriate Group
+
+Choose the group that best matches your blog's topic:
+- **Classical ML**: Linear/logistic regression, decision trees, SVMs, clustering, ensemble methods, performance metrics
+- **Deep Learning**: Neural networks, backpropagation, CNNs, RNNs, optimizers, regularization
+- **NLP**: Text preprocessing, embeddings, transformers, sentiment analysis, language models
+- **Computer Vision**: Image processing, object detection, image classification, facial recognition
+- **Reinforcement Learning**: Q-learning, policy gradients, multi-agent systems, game theory
+- **MLOps**: Model deployment, monitoring, CI/CD, containerization, cloud platforms
+
+#### Step 2: Update Group Configuration Files
+
+You need to update **both** of these JavaScript files:
+
+1. **`assets/js/groups.js`** - Main groups page configuration
+2. **`assets/js/group-detail.js`** - Individual group page configuration
+
+In **both files**, find the appropriate group object and add your blog's ID to the `blogIds` array:
+
+```javascript
+{
+  id: 'classical-ml',
+  title: "Classical ML",
+  // ... other properties
+  blogIds: ['linear-regression', 'performance-metrics', 'your-new-blog-id'], // Add your blog ID here
+  // ... other properties
+}
+```
+
+Also add your blog's metadata to the `blogMetadata` array in **both files**:
+
+```javascript
+const blogMetadata = [
+  // ... existing blogs
+  {
+    id: 'your-new-blog-id',
+    title: "Your Blog Title",
+    subtitle: "Your blog subtitle",
+    html: 'blog-pages/your-blog.html', // Use '../blog-pages/your-blog.html' in group-detail.js
+    tags: ['relevant', 'tags', 'for', 'your', 'blog']
+  }
+];
+```
+
+#### Step 3: Create Group Page (if needed)
+
+If you're adding to a group that doesn't have a dedicated page yet (NLP, Computer Vision, Reinforcement Learning, or MLOps), you'll need to create one:
+
+1. Copy an existing group page from `pages/groups/` (e.g., `classical-ml.html`)
+2. Rename it to match the group ID (e.g., `nlp.html`)
+3. Update the content to reflect the new group's title, description, and topics
+4. Update the script tag at the bottom to use the correct `data-group-id`
+
+#### Step 4: Verify Group Assignment
+
+After adding your blog to a group:
+
+1. Your blog should appear in the group's lesson list
+2. The group's progress bar should reflect completion of your blog's projects
+3. The group should show the correct lesson count
+4. All progress calculations should display with 2 decimal places
+
+### Best Practices for Group Organization
+
+- **One primary group**: Each blog should belong to one primary group to avoid confusion
+- **Relevant grouping**: Choose the group that most closely matches your blog's core topic
+- **Consistent metadata**: Ensure your blog's metadata is identical in both configuration files
+- **Path correctness**: Use relative paths (`blog-pages/`) in `groups.js` and (`../blog-pages/`) in `group-detail.js`
+- **Tag consistency**: Use relevant tags that help with content discovery and filtering
+
+### Progress Tracking
+
+Groups track learning progress with 2-decimal precision:
+- Progress is calculated as: `(completed_blogs / total_blogs) * 100`
+- A blog is considered "completed" when its project tasks reach 100% completion
+- Group progress updates automatically as users complete blog projects
+- Progress displays with format like "66.67% completed" instead of rounded integers
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
-Thank you for contributing to the Zeus Project! 
+Thank you for contributing to the Zeus Project!

--- a/assets/js/group-detail.js
+++ b/assets/js/group-detail.js
@@ -1,0 +1,157 @@
+// Group data (should match groups.js)
+const groups = [
+  {
+    id: 'classical-ml',
+    title: "Classical ML",
+    subtitle: "Master the fundamentals of machine learning with traditional algorithms like linear regression, SVMs, and decision trees. Build a solid foundation before diving into deep learning.",
+    description: "Explore the core principles and mathematics behind classical machine learning algorithms.",
+    topics: ["Linear Regression", "Logistic Regression", "Decision Trees", "Random Forest", "SVM", "K-Means", "Performance Metrics"],
+    blogIds: ['linear-regression', 'performance-metrics'],
+    color: "#A68A6D"
+  },
+  {
+    id: 'deep-learning',
+    title: "Deep Learning",
+    subtitle: "Dive deep into neural networks, from basic perceptrons to advanced architectures. Learn about CNNs, RNNs, and the latest breakthroughs in deep learning.",
+    description: "Understand neural networks and their applications in solving complex problems.",
+    topics: ["Neural Networks", "Backpropagation", "CNNs", "RNNs", "LSTMs", "Optimizers", "Regularization"],
+    blogIds: ['optimizers'],
+    color: "#A68A6D"
+  }
+];
+
+// Blog metadata
+const blogMetadata = [
+  {
+    id: 'linear-regression',
+    title: "Linear Regression",
+    subtitle: "This is the most basic and overlooked in today's machine learning world, when we have advanced stuff, like transformers, RNNs and so much more. But in reality, if you dive deep into any kind of model, it will have linear regression in some form or the other!",
+    html: '../blog-pages/linear-regression.html',
+    tags: ['classical-ml', 'fundamentals', 'regression']
+  },
+  {
+    id: 'optimizers',
+    title: "Optimizers",
+    subtitle: "A deep dive into the evolution of optimization algorithms in deep learning.",
+    html: '../blog-pages/optimizer-theory.html',
+    tags: ['deep-learning', 'optimization', 'neural-networks']
+  },
+  {
+    id: "performance-metrics",
+    title: "Performance Metrics",
+    subtitle: "Performance metrics tell you if your model actually works.",
+    html: "../blog-pages/performance-metrics.html",
+    tags: ['classical-ml', 'evaluation', 'metrics']
+  }
+];
+
+// Get the current group ID from the script tag
+function getCurrentGroupId() {
+  const script = document.querySelector('script[data-group-id]');
+  return script ? script.getAttribute('data-group-id') : null;
+}
+
+// Calculate group progress
+function calculateGroupProgress(groupId) {
+  const group = groups.find(g => g.id === groupId);
+  if (!group || group.blogIds.length === 0) return 0;
+
+  let totalProgress = 0;
+  group.blogIds.forEach(blogId => {
+    const progress = parseFloat(localStorage.getItem(`zeus-progress-${blogId}`) || 0);
+    totalProgress += progress;
+  });
+
+  return parseFloat((totalProgress / group.blogIds.length).toFixed(2));
+}
+
+// Load lessons for the current group
+function loadGroupLessons(groupId) {
+  const group = groups.find(g => g.id === groupId);
+  if (!group) return;
+
+  const lessonsList = document.getElementById('lessons-list');
+  if (!lessonsList) return;
+
+  lessonsList.innerHTML = '';
+
+  group.blogIds.forEach(blogId => {
+    const blog = blogMetadata.find(b => b.id === blogId);
+    if (!blog) return;
+
+    const rawProgress = parseFloat(localStorage.getItem(`zeus-progress-${blogId}`) || 0);
+    const progress = parseFloat(rawProgress.toFixed(2));
+    const isCompleted = progress === 100;
+
+    const card = document.createElement('div');
+    card.className = 'card p-8 flex flex-col items-center fadein';
+
+    card.innerHTML = `
+      <div class="flex-grow">
+        <h3 class="text-2xl font-bold mb-2 text-center text-[#A68A6D] serif">${blog.title}</h3>
+        <p class="text-[#4A3E31] mb-4 outfit text-center">${blog.subtitle}</p>
+      </div>
+      <div class="w-full px-4 mb-4">
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-sm text-[#4A3E31] outfit">Progress</span>
+        </div>
+        <div style="background-color: #F0E6D2; border-radius: 9999px; height: 6px;">
+          <div style="width: ${progress}%; background-color: ${group.color}; height: 100%; border-radius: 9999px; transition: width 0.3s ease-in-out;"></div>
+        </div>
+        ${isCompleted ? '<div class="text-xs text-green-600 outfit mt-1 text-center">✓ Completed</div>' : ''}
+      </div>
+      <a href="${blog.html}" class="inline-block px-6 py-2 rounded-full font-bold text-md bg-[#D7BFAE] hover:bg-[#CBB59A] text-[#3B3025] transition-all duration-200 border border-[#E8D9C3] outfit">
+        ${isCompleted ? 'Review Lesson' : 'Start Lesson'}
+      </a>
+    `;
+
+    lessonsList.appendChild(card);
+  });
+
+  // Fade-in animation for cards
+  const cards = document.querySelectorAll('.fadein');
+  cards.forEach((card, i) => {
+    setTimeout(() => card.classList.add('visible'), 200 + i * 150);
+  });
+}
+
+// Update overall progress display
+function updateOverallProgress(groupId) {
+  const progress = calculateGroupProgress(groupId);
+  const progressBar = document.getElementById('overall-progress');
+  const progressText = document.getElementById('progress-text');
+
+  if (progressBar && progressText) {
+    // Animate progress bar
+    setTimeout(() => {
+      progressBar.style.width = `${progress}%`;
+      progressText.textContent = `In Progress`;
+    }, 500);
+  }
+}
+
+// Initialize the group detail page
+function initializeGroupDetail() {
+  const groupId = getCurrentGroupId();
+  if (!groupId) {
+    console.error('No group ID found');
+    return;
+  }
+
+  loadGroupLessons(groupId);
+  updateOverallProgress(groupId);
+}
+
+// Listen for storage changes to update progress in real-time
+window.addEventListener('storage', function(e) {
+  if (e.key && e.key.startsWith('zeus-progress-')) {
+    const groupId = getCurrentGroupId();
+    if (groupId) {
+      updateOverallProgress(groupId);
+      loadGroupLessons(groupId);
+    }
+  }
+});
+
+// Initialize when DOM is loaded
+document.addEventListener('DOMContentLoaded', initializeGroupDetail);

--- a/assets/js/groups.js
+++ b/assets/js/groups.js
@@ -1,0 +1,168 @@
+const groups = [
+  {
+    id: 'classical-ml',
+    title: "Classical ML",
+    subtitle: "Master the fundamentals of machine learning with traditional algorithms like linear regression, SVMs, and decision trees. Build a solid foundation before diving into deep learning.",
+    description: "Explore the core principles and mathematics behind classical machine learning algorithms.",
+    topics: ["Linear Regression", "Logistic Regression", "Decision Trees", "Random Forest", "SVM", "K-Means", "Performance Metrics"],
+    blogIds: ['linear-regression', 'performance-metrics'],
+    color: "#A68A6D"
+  },
+  {
+    id: 'deep-learning',
+    title: "Deep Learning",
+    subtitle: "Dive deep into neural networks, from basic perceptrons to advanced architectures. Learn about CNNs, RNNs, and the latest breakthroughs in deep learning.",
+    description: "Understand neural networks and their applications in solving complex problems.",
+    topics: ["Neural Networks", "Backpropagation", "CNNs", "RNNs", "LSTMs", "Optimizers", "Regularization"],
+    blogIds: ['optimizers'],
+    color: "#A68A6D"
+  },
+  {
+    id: 'nlp',
+    title: "Natural Language Processing",
+    subtitle: "Process and understand human language with computers. From text preprocessing to transformers, explore how machines comprehend and generate text.",
+    description: "Learn to build systems that can understand, interpret, and generate human language.",
+    topics: ["Text Preprocessing", "Word Embeddings", "Sentiment Analysis", "Named Entity Recognition", "Transformers", "BERT", "GPT"],
+    blogIds: [],
+    color: "#A68A6D"
+  },
+  {
+    id: 'computer-vision',
+    title: "Computer Vision",
+    subtitle: "Teach machines to see and understand visual content. Learn image processing, object detection, and how to build AI systems that can analyze visual data.",
+    description: "Develop skills in image processing, pattern recognition, and visual AI applications.",
+    topics: ["Image Processing", "Feature Detection", "Object Detection", "Image Classification", "CNNs", "YOLO", "Face Recognition"],
+    blogIds: [],
+    color: "#A68A6D"
+  },
+  {
+    id: 'reinforcement-learning',
+    title: "Reinforcement Learning",
+    subtitle: "Train agents to make decisions through trial and error. Explore how AI systems learn optimal strategies in dynamic environments.",
+    description: "Master the art of training AI agents to make sequential decisions and learn from experience.",
+    topics: ["Q-Learning", "Policy Gradients", "Actor-Critic", "Deep Q-Networks", "Multi-Agent RL", "Game Theory"],
+    blogIds: [],
+    color: "#A68A6D"
+  },
+  {
+    id: 'mlops',
+    title: "MLOps & Deployment",
+    subtitle: "Bridge the gap between development and production. Learn to deploy, monitor, and maintain ML models in real-world applications.",
+    description: "Learn the practical skills needed to deploy and maintain ML systems in production.",
+    topics: ["Model Deployment", "Docker", "CI/CD", "Model Monitoring", "A/B Testing", "Data Pipelines", "Cloud Platforms"],
+    blogIds: [],
+    color: "#A68A6D"
+  }
+];
+
+// Blog metadata with tags for filtering
+const blogMetadata = [
+  {
+    id: 'linear-regression',
+    title: "Linear Regression",
+    subtitle: "This is the most basic and overlooked in today's machine learning world, when we have advanced stuff, like transformers, RNNs and so much more. But in reality, if you dive deep into any kind of model, it will have linear regression in some form or the other!",
+    html: 'blog-pages/linear-regression.html',
+    tags: ['classical-ml', 'fundamentals', 'regression']
+  },
+  {
+    id: 'optimizers',
+    title: "Optimizers",
+    subtitle: "A deep dive into the evolution of optimization algorithms in deep learning.",
+    html: 'blog-pages/optimizer-theory.html',
+    tags: ['deep-learning', 'optimization', 'neural-networks']
+  },
+  {
+    id: "performance-metrics",
+    title: "Performance Metrics",
+    subtitle: "Performance metrics tell you if your model actually works.",
+    html: "blog-pages/performance-metrics.html",
+    tags: ['classical-ml', 'evaluation', 'metrics']
+  }
+];
+
+function getGroupProgress(groupId) {
+  const group = groups.find(g => g.id === groupId);
+  if (!group || group.blogIds.length === 0) return 0;
+
+  let totalProgress = 0;
+  group.blogIds.forEach(blogId => {
+    const progress = parseFloat(localStorage.getItem(`zeus-progress-${blogId}`) || 0);
+    totalProgress += progress;
+  });
+
+  return parseFloat((totalProgress / group.blogIds.length).toFixed(2));
+}
+
+function loadGroups(groupsToLoad) {
+  const groupsList = document.getElementById('groups-list');
+  groupsList.innerHTML = ''; // Clear existing groups
+
+  groupsToLoad.forEach(group => {
+    const card = document.createElement('div');
+    card.className = 'card p-8 flex flex-col items-center fadein cursor-pointer group-card';
+    const progress = getGroupProgress(group.id);
+    const blogCount = group.blogIds.length;
+
+    card.innerHTML = `
+      <div class="flex-grow text-center">
+        <h2 class="text-2xl font-bold mb-2 text-[#A68A6D] serif">${group.title}</h2>
+        <p class="text-[#4A3E31] mb-4 outfit">${group.subtitle}</p>
+        <div class="mb-4">
+          <div class="text-sm text-[#4A3E31] mb-2 outfit">
+            ${blogCount} lesson${blogCount !== 1 ? 's' : ''} available
+          </div>
+          ${blogCount > 0 ? `
+            <div class="w-full px-4 mb-2">
+              <div style="background-color: #F0E6D2; border-radius: 9999px; height: 6px;">
+                <div style="width: ${progress}%; background-color: ${group.color}; height: 100%; border-radius: 9999px; transition: width 0.3s ease-in-out;"></div>
+              </div>
+            </div>
+          ` : `
+            <div class="text-xs text-[#A68A6D] outfit italic">Coming Soon</div>
+          `}
+        </div>
+        <div class="flex flex-wrap gap-1 justify-center mb-4">
+          ${group.topics.slice(0, 4).map(topic =>
+            `<span class="text-xs px-2 py-1 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit">${topic}</span>`
+          ).join('')}
+          ${group.topics.length > 4 ? `<span class="text-xs px-2 py-1 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit">+${group.topics.length - 4} more</span>` : ''}
+        </div>
+      </div>
+      <button class="inline-block px-6 py-2 rounded-full font-bold text-md bg-[#D7BFAE] hover:bg-[#CBB59A] text-[#3B3025] transition-all duration-200 border border-[#E8D9C3] outfit group-btn">
+        ${blogCount > 0 ? 'Explore Group' : 'Coming Soon'}
+      </button>
+    `;
+
+    if (blogCount > 0) {
+      card.addEventListener('click', () => {
+        window.location.href = `/pages/groups/${group.id}.html`;
+      });
+    } else {
+      card.style.opacity = '0.7';
+      card.style.cursor = 'default';
+    }
+
+    groupsList.appendChild(card);
+  });
+
+  // Fade-in animation for cards
+  const cards = document.querySelectorAll('.fadein');
+  cards.forEach((card, i) => {
+    setTimeout(() => card.classList.add('visible'), 200 + i * 150);
+  });
+}
+
+loadGroups(groups);
+
+const searchBar = document.getElementById('search-bar');
+searchBar.addEventListener('keyup', (e) => {
+    const searchString = e.target.value.toLowerCase();
+    const filteredGroups = groups.filter(group => {
+        return (
+            group.title.toLowerCase().includes(searchString) ||
+            group.subtitle.toLowerCase().includes(searchString) ||
+            group.topics.some(topic => topic.toLowerCase().includes(searchString))
+        );
+    });
+    loadGroups(filteredGroups);
+});

--- a/index.html
+++ b/index.html
@@ -39,6 +39,13 @@
           </li>
           <li>
             <a
+              href="/pages/groups.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Groups</a
+            >
+          </li>
+          <li>
+            <a
               href="/pages/about.html"
               class="hover:text-[#A68A6D] transition-colors"
               >About</a

--- a/pages/blog-pages/linear-regression.html
+++ b/pages/blog-pages/linear-regression.html
@@ -372,6 +372,13 @@
           </li>
           <li>
             <a
+              href="/pages/groups.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Groups</a
+            >
+          </li>
+          <li>
+            <a
               href="/pages/about.html"
               class="hover:text-[#A68A6D] transition-colors"
               >About</a

--- a/pages/blog-pages/optimizer-theory.html
+++ b/pages/blog-pages/optimizer-theory.html
@@ -367,6 +367,13 @@
           </li>
           <li>
             <a
+              href="/pages/groups.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Groups</a
+            >
+          </li>
+          <li>
+            <a
               href="/pages/about.html"
               class="hover:text-[#A68A6D] transition-colors"
               >About</a

--- a/pages/blog-pages/performance-metrics.html
+++ b/pages/blog-pages/performance-metrics.html
@@ -255,6 +255,7 @@
       <ul class="flex space-x-6 text-lg outfit font-semibold">
         <li><a href="../../index.html" class="hover:text-[#A68A6D] transition-colors">Home</a></li>
         <li><a href="../curriculum.html" class="hover:text-[#A68A6D] transition-colors">Curriculum</a></li>
+        <li><a href="../groups.html" class="hover:text-[#A68A6D] transition-colors">Groups</a></li>
         <li><a href="../about.html" class="hover:text-[#A68A6D] transition-colors">About</a></li>
       </ul>
     </nav>
@@ -321,7 +322,7 @@
         .then(text => {
           const frontmatterRegex = /---\s*([\s\S]*?)\s*---/;
           const match = text.match(frontmatterRegex);
-  
+
           let content = text;
           if (match) {
             const frontmatter = match[1];
@@ -337,9 +338,9 @@
             lessonSubtitleEl.innerText = metadata.subtitle || 'Understanding Model Performance';
             contributorNameEl.innerText = metadata.author || 'yashasnadigsyn';
           }
-          
+
           lessonContentEl.innerHTML = marked.parse(content);
-  
+
           renderMathInElement(lessonContentEl, {
             delimiters: [
               {left: '$$', right: '$$', display: true},
@@ -350,7 +351,7 @@
           });
           hljs.highlightAll();
           generateTOC();
-  
+
           setTimeout(() => {
             document.querySelector('.fadein').classList.add('visible');
           }, 100);
@@ -367,7 +368,7 @@
         document.getElementById('share-twitter').href = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
         document.getElementById('share-linkedin').href = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
     }
-    
+
     function setupTOC() {
       const tocToggle = document.getElementById('toc-toggle');
       const tocSidebar = document.getElementById('toc-sidebar');
@@ -382,13 +383,13 @@
       tocToggle.addEventListener('click', toggleTOC);
       tocOverlay.addEventListener('click', toggleTOC);
     }
-    
+
     function generateTOC() {
       const content = document.getElementById('lesson-content');
       const tocList = document.getElementById('toc-list');
       tocList.innerHTML = '';
       const headings = content.querySelectorAll('h1, h2, h3, h4, h5, h6');
-      
+
       headings.forEach(heading => {
         const id = heading.textContent.trim().toLowerCase().replace(/\s+/g, '-');
         heading.id = id;
@@ -412,24 +413,24 @@
                 projectContainer.innerHTML = html;
 
                 const projectHTMLs = projectContainer.innerHTML.split('<hr>');
-                
-                projectsSection.innerHTML = ''; 
+
+                projectsSection.innerHTML = '';
 
                 projectHTMLs.forEach((projectHTML, projectIndex) => {
                     const projectCard = document.createElement('div');
                     projectCard.className = 'project-card';
                     projectCard.innerHTML = `<div class="project-tasks">${projectHTML}</div>`;
                     projectsSection.appendChild(projectCard);
-                    
+
                     const listItems = projectCard.querySelectorAll('.project-tasks li');
                     const progressBar = projectCard.querySelector('.progress-bar');
-                    
+
                     listItems.forEach((li, taskIndex) => {
                         const checkbox = li.querySelector('input[type="checkbox"]');
                         if (!checkbox) return;
 
                         const isParentTask = li.querySelector('ul') !== null;
-                        
+
                         // Wrap text content in a span for styling
                         const textNode = checkbox.nextSibling;
                         const span = document.createElement('span');
@@ -451,7 +452,7 @@
                             // It's a sub-task, enable it and add listeners
                             checkbox.disabled = false;
                             const taskId = `${LESSON_ID}-project-${projectIndex}-task-${taskIndex}`;
-                            
+
                             const applyStyles = () => {
                                 if (checkbox.checked) {
                                     span.classList.add('task-completed');
@@ -459,7 +460,7 @@
                                     span.classList.remove('task-completed');
                                 }
                             };
-                            
+
                             if (localStorage.getItem(taskId) === 'true') {
                                 checkbox.checked = true;
                             }
@@ -482,7 +483,7 @@
                             progressBar.style.width = `${progress}%`;
                         }
                     };
-                    
+
                     updateProgress();
                 });
 
@@ -503,4 +504,4 @@
 
   </script>
 </body>
-</html> 
+</html>

--- a/pages/curriculum.html
+++ b/pages/curriculum.html
@@ -41,6 +41,13 @@
           </li>
           <li>
             <a
+              href="/pages/groups.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Groups</a
+            >
+          </li>
+          <li>
+            <a
               href="/pages/about.html"
               class="hover:text-[#A68A6D] transition-colors"
               >About</a

--- a/pages/groups.html
+++ b/pages/groups.html
@@ -3,8 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>About Zeus Project</title>
+    <title>Zeus Project Groups</title>
     <link rel="icon" href="../favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Outfit:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <link href="../assets/css/styles.css" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
@@ -52,34 +56,33 @@
         </ul>
       </nav>
     </header>
-    <main class="max-w-3xl mx-auto px-4 py-8 sm:py-16 flex-grow">
-      <section class="text-center mb-8 sm:mb-12">
+    <main class="max-w-4xl mx-auto px-4 py-8 sm:py-16 flex-grow">
+      <section class="text-center mb-12 sm:mb-16">
         <h1
           class="text-3xl sm:text-4xl md:text-5xl font-extrabold mb-4 text-[#b1a091] serif tracking-wider leading-relaxed"
         >
-          About The Zeus Project
+          Learning Groups
         </h1>
         <p class="text-lg md:text-xl text-[#4A3E31] mb-6 sm:mb-8 outfit px-2">
-          Empowering the next generation of machine learning engineers.
+          Explore topic-centric learning tracks designed to complement our curriculum.
+          Each group offers curated content and a structured learning path.
         </p>
       </section>
-      <section class="card p-6 sm:p-8 mb-12 sm:mb-20 fadein">
-        <h2 class="text-xl sm:text-2xl font-bold mb-4 text-[#A68A6D] serif">
-          Our Mission
-        </h2>
-        <p class="text-[#4A3E31] mb-6 outfit text-sm sm:text-base">
-          The Zeus Project is dedicated to providing a free, open-source, and
-          comprehensive curriculum for learning machine learning. We believe in
-          accessible education for all, with a focus on hands-on projects and
-          real-world applications.
-        </p>
-        <h2 class="text-xl sm:text-2xl font-bold mb-4 text-[#A68A6D] serif">
-          Our Vision
-        </h2>
-        <p class="text-[#4A3E31] outfit text-sm sm:text-base">
-          To build a global community of learners and contributors passionate
-          about advancing the field of machine learning.
-        </p>
+
+      <div class="mb-6 sm:mb-8 px-2 sm:px-4">
+        <input
+          type="text"
+          id="search-bar"
+          placeholder="Search for groups..."
+          class="w-full px-4 py-2 rounded-full border border-[#F0E6D2] bg-[#FAF3E0] focus:outline-none focus:ring-2 focus:ring-[#A68A6D] outfit"
+        />
+      </div>
+
+      <section
+        id="groups-list"
+        class="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8 mb-12 sm:mb-20"
+      >
+        <!-- Groups will be injected here by JS -->
       </section>
     </main>
     <footer
@@ -109,6 +112,6 @@
         >
       </div>
     </footer>
-    <script src="../assets/js/about.js"></script>
+    <script src="../assets/js/groups.js"></script>
   </body>
 </html>

--- a/pages/groups/classical-ml.html
+++ b/pages/groups/classical-ml.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Classical ML | Zeus Project Groups</title>
+    <link rel="icon" href="../../favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Outfit:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link href="../../assets/css/styles.css" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="cream-bg min-h-screen text-[#3B3025] flex flex-col">
+    <header
+      class="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-[#F0E6D2] bg-[#FAF3E0]"
+    >
+      <div
+        class="text-xl sm:text-2xl font-bold tracking-wide serif text-[#A68A6D]"
+      >
+        The Zeus Project
+      </div>
+      <nav>
+        <ul
+          class="flex space-x-3 sm:space-x-6 text-sm sm:text-lg outfit font-semibold"
+        >
+          <li>
+            <a
+              href="../../index.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Home</a
+            >
+          </li>
+          <li>
+            <a
+              href="/pages/curriculum.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Curriculum</a
+            >
+          </li>
+          <li>
+            <a
+              href="/pages/groups.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Groups</a
+            >
+          </li>
+          <li>
+            <a
+              href="/pages/about.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >About</a
+            >
+          </li>
+        </ul>
+      </nav>
+    </header>
+
+    <!-- Breadcrumb -->
+    <div class="max-w-4xl mx-auto px-4 py-4">
+      <nav class="text-sm outfit">
+        <a href="/pages/groups.html" class="text-[#A68A6D] hover:underline">Groups</a>
+        <span class="mx-2 text-[#4A3E31]">/</span>
+        <span class="text-[#4A3E31] font-semibold">Classical ML</span>
+      </nav>
+    </div>
+
+    <main class="max-w-4xl mx-auto px-4 py-4 sm:py-8 flex-grow">
+      <!-- Group Header -->
+      <section class="text-center mb-8 sm:mb-12">
+        <h1
+          class="text-3xl sm:text-4xl md:text-5xl font-extrabold mb-4 text-[#b1a091] serif tracking-wider leading-relaxed"
+        >
+          Classical Machine Learning
+        </h1>
+        <p class="text-lg md:text-xl text-[#4A3E31] mb-6 sm:mb-8 outfit px-2 max-w-3xl mx-auto">
+          Master the fundamentals of machine learning with traditional algorithms like linear regression, SVMs, and decision trees.
+          Build a solid foundation before diving into deep learning.
+        </p>
+
+        <!-- Progress Overview -->
+        <div class="max-w-md mx-auto mb-8">
+          <div class="text-sm text-[#4A3E31] mb-2 outfit font-semibold">Overall Progress</div>
+          <div class="w-full px-4 mb-2">
+            <div style="background-color: #F0E6D2; border-radius: 9999px; height: 8px;">
+              <div id="overall-progress" style="width: 0%; background-color: #A68A6D; height: 100%; border-radius: 9999px; transition: width 0.5s ease-in-out;"></div>
+            </div>
+          </div>
+          <div id="progress-text" class="text-sm text-[#4A3E31] outfit">In Progress</div>
+        </div>
+      </section>
+
+      <!-- Learning Path -->
+      <section class="mb-12">
+        <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-[#A68A6D] serif text-center">Learning Path</h2>
+        <div class="card p-6 sm:p-8 mb-8">
+          <h3 class="text-xl font-bold mb-4 text-[#A68A6D] serif">Recommended Learning Order</h3>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <h4 class="font-semibold text-[#4A3E31] outfit mb-2">📚 Fundamentals</h4>
+              <ul class="text-sm text-[#4A3E31] outfit space-y-1 mb-4">
+                <li>• Linear Regression</li>
+                <li>• Performance Metrics</li>
+                <li>• Logistic Regression</li>
+              </ul>
+            </div>
+            <div>
+              <h4 class="font-semibold text-[#4A3E31] outfit mb-2">🌳 Advanced Algorithms</h4>
+              <ul class="text-sm text-[#4A3E31] outfit space-y-1 mb-4">
+                <li>• Decision Trees</li>
+                <li>• Random Forest</li>
+                <li>• Support Vector Machines</li>
+                <li>• K-Means Clustering</li>
+              </ul>
+            </div>
+          </div>
+          <div class="mt-4 p-4 bg-[#FFF8F0] rounded-lg border border-[#F0E6D2]">
+            <p class="text-sm text-[#A68A6D] outfit italic">
+              💡 <strong>Tip:</strong> Start with Linear Regression to understand the mathematical foundations,
+              then learn about Performance Metrics to evaluate your models effectively.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Available Lessons -->
+      <section class="mb-12">
+        <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-[#A68A6D] serif text-center">Available Lessons</h2>
+        <div id="lessons-list" class="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8">
+          <!-- Lessons will be injected here by JS -->
+        </div>
+      </section>
+
+      <!-- Topics Overview -->
+      <section class="mb-12">
+        <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-[#A68A6D] serif text-center">Topics Covered</h2>
+        <div class="card p-6 sm:p-8">
+          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Linear Regression</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Logistic Regression</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Decision Trees</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Random Forest</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">SVM</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">K-Means</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Performance Metrics</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer
+      class="flex flex-col md:flex-row justify-between items-center py-4 sm:py-6 px-4 border-t border-[#F0E6D2] bg-[#FAF3E0] text-xs serif"
+    >
+      <div class="mb-2 md:mb-0 text-[#A68A6D]">
+        &copy; 2025 The Zeus Project
+      </div>
+      <div class="flex space-x-3 sm:space-x-4">
+        <a
+          href="https://github.com/thezeusproject/thezeusproject.github.io"
+          class="hover:text-[#A68A6D] transition-colors"
+          aria-label="GitHub"
+          >GitHub</a
+        >
+        <a
+          href="#"
+          class="hover:text-[#A68A6D] transition-colors"
+          aria-label="Discord"
+          >Discord</a
+        >
+        <a
+          href="#"
+          class="hover:text-[#A68A6D] transition-colors"
+          aria-label="Twitter"
+          >Twitter</a
+        >
+      </div>
+    </footer>
+    <script src="../../assets/js/group-detail.js" data-group-id="classical-ml"></script>
+  </body>
+</html>

--- a/pages/groups/deep-learning.html
+++ b/pages/groups/deep-learning.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deep Learning | Zeus Project Groups</title>
+    <link rel="icon" href="../../favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Outfit:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link href="../../assets/css/styles.css" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="cream-bg min-h-screen text-[#3B3025] flex flex-col">
+    <header
+      class="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-[#F0E6D2] bg-[#FAF3E0]"
+    >
+      <div
+        class="text-xl sm:text-2xl font-bold tracking-wide serif text-[#A68A6D]"
+      >
+        The Zeus Project
+      </div>
+      <nav>
+        <ul
+          class="flex space-x-3 sm:space-x-6 text-sm sm:text-lg outfit font-semibold"
+        >
+          <li>
+            <a
+              href="../../index.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Home</a
+            >
+          </li>
+          <li>
+            <a
+              href="/pages/curriculum.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Curriculum</a
+            >
+          </li>
+          <li>
+            <a
+              href="/pages/groups.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >Groups</a
+            >
+          </li>
+          <li>
+            <a
+              href="/pages/about.html"
+              class="hover:text-[#A68A6D] transition-colors"
+              >About</a
+            >
+          </li>
+        </ul>
+      </nav>
+    </header>
+
+    <!-- Breadcrumb -->
+    <div class="max-w-4xl mx-auto px-4 py-4">
+      <nav class="text-sm outfit">
+        <a href="/pages/groups.html" class="text-[#A68A6D] hover:underline">Groups</a>
+        <span class="mx-2 text-[#4A3E31]">/</span>
+        <span class="text-[#4A3E31] font-semibold">Deep Learning</span>
+      </nav>
+    </div>
+
+    <main class="max-w-4xl mx-auto px-4 py-4 sm:py-8 flex-grow">
+      <!-- Group Header -->
+      <section class="text-center mb-8 sm:mb-12">
+        <h1
+          class="text-3xl sm:text-4xl md:text-5xl font-extrabold mb-4 text-[#b1a091] serif tracking-wider leading-relaxed"
+        >
+          Deep Learning
+        </h1>
+        <p class="text-lg md:text-xl text-[#4A3E31] mb-6 sm:mb-8 outfit px-2 max-w-3xl mx-auto">
+          Dive deep into neural networks, from basic perceptrons to advanced architectures.
+          Learn about CNNs, RNNs, and the latest breakthroughs in deep learning.
+        </p>
+
+        <!-- Progress Overview -->
+        <div class="max-w-md mx-auto mb-8">
+          <div class="text-sm text-[#4A3E31] mb-2 outfit font-semibold">Overall Progress</div>
+          <div class="w-full px-4 mb-2">
+            <div style="background-color: #F0E6D2; border-radius: 9999px; height: 8px;">
+              <div id="overall-progress" style="width: 0%; background-color: #A68A6D; height: 100%; border-radius: 9999px; transition: width 0.5s ease-in-out;"></div>
+            </div>
+          </div>
+          <div id="progress-text" class="text-sm text-[#4A3E31] outfit">In Progress</div>
+        </div>
+      </section>
+
+      <!-- Learning Path -->
+      <section class="mb-12">
+        <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-[#A68A6D] serif text-center">Learning Path</h2>
+        <div class="card p-6 sm:p-8 mb-8">
+          <h3 class="text-xl font-bold mb-4 text-[#A68A6D] serif">Recommended Learning Order</h3>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <h4 class="font-semibold text-[#4A3E31] outfit mb-2">🧱 Foundations</h4>
+              <ul class="text-sm text-[#4A3E31] outfit space-y-1 mb-4">
+                <li>• Neural Networks</li>
+                <li>• Backpropagation</li>
+                <li>• Optimizers</li>
+              </ul>
+            </div>
+            <div>
+              <h4 class="font-semibold text-[#4A3E31] outfit mb-2">🚀 Advanced Architectures</h4>
+              <ul class="text-sm text-[#4A3E31] outfit space-y-1 mb-4">
+                <li>• Convolutional Neural Networks</li>
+                <li>• Recurrent Neural Networks</li>
+                <li>• LSTMs & GRUs</li>
+                <li>• Regularization Techniques</li>
+              </ul>
+            </div>
+          </div>
+          <div class="mt-4 p-4 bg-[#FFF8F0] rounded-lg border border-[#F0E6D2]">
+            <p class="text-sm text-[#A68A6D] outfit italic">
+              💡 <strong>Tip:</strong> Start with understanding basic neural networks and backpropagation,
+              then explore different optimization algorithms before moving to specialized architectures.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Available Lessons -->
+      <section class="mb-12">
+        <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-[#A68A6D] serif text-center">Available Lessons</h2>
+        <div id="lessons-list" class="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8">
+          <!-- Lessons will be injected here by JS -->
+        </div>
+      </section>
+
+      <!-- Topics Overview -->
+      <section class="mb-12">
+        <h2 class="text-2xl sm:text-3xl font-bold mb-6 text-[#A68A6D] serif text-center">Topics Covered</h2>
+        <div class="card p-6 sm:p-8">
+          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Neural Networks</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Backpropagation</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">CNNs</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">RNNs</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">LSTMs</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Optimizers</span>
+            <span class="text-sm px-3 py-2 rounded-full bg-[#F0E6D2] text-[#4A3E31] outfit text-center">Regularization</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer
+      class="flex flex-col md:flex-row justify-between items-center py-4 sm:py-6 px-4 border-t border-[#F0E6D2] bg-[#FAF3E0] text-xs serif"
+    >
+      <div class="mb-2 md:mb-0 text-[#A68A6D]">
+        &copy; 2025 The Zeus Project
+      </div>
+      <div class="flex space-x-3 sm:space-x-4">
+        <a
+          href="https://github.com/thezeusproject/thezeusproject.github.io"
+          class="hover:text-[#A68A6D] transition-colors"
+          aria-label="GitHub"
+          >GitHub</a
+        >
+        <a
+          href="#"
+          class="hover:text-[#A68A6D] transition-colors"
+          aria-label="Discord"
+          >Discord</a
+        >
+        <a
+          href="#"
+          class="hover:text-[#A68A6D] transition-colors"
+          aria-label="Twitter"
+          >Twitter</a
+        >
+      </div>
+    </footer>
+    <script src="../../assets/js/group-detail.js" data-group-id="deep-learning"></script>
+  </body>
+</html>


### PR DESCRIPTION
Description
Added a new "Groups" section to the navbar for topic-based learning in AI/ML (e.g., Deep Learning, NLP). Each group has a dedicated page with:

Intro to the topic
Optional reading paths
Progress tracking via localStorage
Layout matching the Curriculum section

Routes are under /groups/<group-name>, and blog content is filtered by tags. This helps users explore specific domains and track their progress.