### PR TITLE
fix(#24): remove invalid Zone.Identifier file to fix Windows clone error

### DIFF
--- a/assets/icons/discord.svg:Zone.Identifier
+++ b/assets/icons/discord.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://simpleicons.org/

--- a/assets/icons/github.svg:Zone.Identifier
+++ b/assets/icons/github.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://simpleicons.org/

--- a/assets/icons/theodinproject.svg:Zone.Identifier
+++ b/assets/icons/theodinproject.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://simpleicons.org/

--- a/assets/icons/x.svg:Zone.Identifier
+++ b/assets/icons/x.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://simpleicons.org/


### PR DESCRIPTION
This PR removes `.Zone.Identifier` files in `assets/icons/` that contained colons in their names (e.g., `discord.svg:Zone.Identifier`). These files cause errors when cloning or checking out the repository on Windows systems, because colons are not allowed in filenames on NTFS.

Fixes #24

![image](https://github.com/user-attachments/assets/2a1afe09-61b6-433c-a538-0728f6baf41a)

