### PR TITLE
feat: Add 'Copy Code' button to linear-regression.html and performance-metrics.html

### DIFF
--- a/pages/blog-pages/linear-regression.html
+++ b/pages/blog-pages/linear-regression.html
@@ -530,6 +530,43 @@
               ],
             });
             hljs.highlightAll();
+            document.querySelectorAll("pre").forEach((preBlock) => {
+              const button = document.createElement("button");
+              button.innerText = "Copy";
+              button.className = "copy-btn";
+              button.style.cssText = `
+                position: absolute;
+                top: 8px;
+                right: 8px;
+                padding: 4px 10px;
+                font-size: 12px;
+                cursor: pointer;
+                background: linear-gradient(90deg, #d7bfae 0%, #cbb59a 100%);
+                color: #3b3025;
+                font-family: "Outfit", sans-serif;
+                font-weight: 600;
+                border: 1px solid #e8d9c3;
+                border-radius: 0.75rem;
+                box-shadow: 0 2px 4px rgba(215, 191, 174, 0.15);
+                transition: background 0.2s, box-shadow 0.2s;
+                z-index: 10;
+                opacity: 0.85;
+              `;
+
+              const wrapper = document.createElement("div");
+              wrapper.style.position = "relative";
+              preBlock.parentNode.insertBefore(wrapper, preBlock);
+              wrapper.appendChild(preBlock);
+              wrapper.appendChild(button);
+
+              button.addEventListener("click", () => {
+                const code = preBlock.innerText;
+                navigator.clipboard.writeText(code).then(() => {
+                  button.innerText = "Copied!";
+                  setTimeout(() => (button.innerText = "Copy"), 2000);
+                });
+              });
+            });
             generateTOC();
 
             setTimeout(() => {

--- a/pages/blog-pages/performance-metrics.html
+++ b/pages/blog-pages/performance-metrics.html
@@ -349,6 +349,43 @@
             ]
           });
           hljs.highlightAll();
+          document.querySelectorAll("pre").forEach((preBlock) => {
+              const button = document.createElement("button");
+              button.innerText = "Copy";
+              button.className = "copy-btn";
+              button.style.cssText = `
+                position: absolute;
+                top: 8px;
+                right: 8px;
+                padding: 4px 10px;
+                font-size: 12px;
+                cursor: pointer;
+                background: linear-gradient(90deg, #d7bfae 0%, #cbb59a 100%);
+                color: #3b3025;
+                font-family: "Outfit", sans-serif;
+                font-weight: 600;
+                border: 1px solid #e8d9c3;
+                border-radius: 0.75rem;
+                box-shadow: 0 2px 4px rgba(215, 191, 174, 0.15);
+                transition: background 0.2s, box-shadow 0.2s;
+                z-index: 10;
+                opacity: 0.85;
+              `;
+
+              const wrapper = document.createElement("div");
+              wrapper.style.position = "relative";
+              preBlock.parentNode.insertBefore(wrapper, preBlock);
+              wrapper.appendChild(preBlock);
+              wrapper.appendChild(button);
+
+              button.addEventListener("click", () => {
+                const code = preBlock.innerText;
+                navigator.clipboard.writeText(code).then(() => {
+                  button.innerText = "Copied!";
+                  setTimeout(() => (button.innerText = "Copy"), 2000);
+                });
+              });
+            });
           generateTOC();
   
           setTimeout(() => {


### PR DESCRIPTION
Added a "Copy" button to all code blocks in the following pages:

- `linear-regression.html`
- `performance-metrics.html`

This allows users to easily copy code snippets with a single click, improving user experience and usability when reading and trying out the code examples.

Styling of the button has been matched to the site’s theme for visual consistency.

<img width="1680" alt="Screenshot 2025-06-27 at 3 29 10 PM" src="https://github.com/user-attachments/assets/ab3403b9-1a63-414b-a330-39e1f73ee104" />

<img width="1680" alt="Screenshot 2025-06-27 at 3 24 31 PM" src="https://github.com/user-attachments/assets/546483e7-8d8a-4607-8371-079d9f8cdfdc" />
